### PR TITLE
Mode hook

### DIFF
--- a/polymode.el
+++ b/polymode.el
@@ -643,7 +643,9 @@ most frequently used slots are:
                                           (current-message)))))
                  (message ,(format "%s enabled" (concat root-name " polymode")))))
              (force-mode-line-update)
-             (pm--run-derived-mode-hooks ,config-name)
+             (let ((obj (clone ,config-name)))
+               (eieio-oset obj '-minor-mode ',mode)
+               (pm--run-derived-mode-hooks obj))
              ,@(when after-hook `(,after-hook)))
            ;; Return the new state
            ,mode)

--- a/tests/mode-hook.el
+++ b/tests/mode-hook.el
@@ -1,0 +1,12 @@
+(require 'polymode-test-utils)
+(require 'cl)
+
+(ert-deftest mode-hook/runs ()
+  (lexical-let (flag)
+    (defcustom poly-test-mode-hook nil
+      "Hook for poly-test-mode"
+      :type 'hook)
+    (add-hook 'poly-test-mode-hook (lambda () (setq flag t)))
+    (define-polymode poly-test-mode)
+    (poly-test-mode)
+    (should flag)))


### PR DESCRIPTION
Documentation says

> Standard hook MODE-hook is run at the end of the initialization
of each polymode buffer (both indirect and base buffers).

but I've not found that to be the case.