### PR TITLE
[bug] Remove ^L characters

### DIFF
--- a/polymode-base.el
+++ b/polymode-base.el
@@ -29,7 +29,7 @@
 
 (require 'polymode-core)
 
-
+
 ;; HOST MODES
 
 (define-obsolete-variable-alias 'pm-host/ada 'poly-ada-hostmode "v0.2")
@@ -84,7 +84,7 @@
 (define-obsolete-variable-alias 'pm-host/yaml 'poly-yaml-hostmode "v0.2")
 (define-hostmode poly-yaml-hostmode :mode 'yaml-mode)
 
-
+
 ;;; ROOT POLYMODES
 
 ;; These are simple generic configuration objects. More specialized polymodes

--- a/polymode-compat.el
+++ b/polymode-compat.el
@@ -40,7 +40,7 @@
   "Polymode compatibility settings."
   :group 'polymode)
 
-
+
 ;;; emacs 25 compat
 
 (unless (fboundp 'assoc-delete-all)
@@ -69,7 +69,7 @@ Elements of ALIST that are not conses are ignored."
     (assoc-delete-all key alist #'eq)))
 
 
-
+
 ;;; Various Wrappers for Around Advice
 
 (defvar *span* nil)
@@ -176,13 +176,13 @@ passed to ORIG-FUN."
         (pm-apply-protected orig-fun args))
     (apply orig-fun args)))
 
-
+
 ;;; Flyspel
 (defun pm--flyspel-dont-highlight-in-chunkmodes (beg end _poss)
   (or (car (get-text-property beg :pm-span))
       (car (get-text-property end :pm-span))))
 
-
+
 ;;; C/C++/Java
 (pm-around-advice 'c-before-context-fl-expand-region #'pm-override-output-cons)
 ;; (advice-remove 'c-before-context-fl-expand-region #'pm-override-output-cons)
@@ -192,7 +192,7 @@ passed to ORIG-FUN."
 ;; (pm-around-advice 'font-lock-default-fontify-region #'pm-substitute-beg-end)
 (pm-around-advice 'c-determine-limit #'pm-execute-narrowed-to-span)
 
-
+
 ;;; Python
 (declare-function pm--first-line-indent "polymode-methods")
 (defun pm--python-dont-indent-to-0 (fun)
@@ -205,7 +205,7 @@ passed to ORIG-FUN."
 
 (pm-around-advice 'python-indent-line-function #'pm--python-dont-indent-to-0)
 
-
+
 ;;; Core Font Lock
 (defvar font-lock-beg)
 (defvar font-lock-end)
@@ -224,7 +224,7 @@ changes."
 (pm-around-advice #'font-lock-extend-region-multiline
                   #'pm-check-for-real-change-in-extend-multiline)
 
-
+
 ;;; Editing
 
 ;; (pm-around-advice 'fill-paragraph #'pm-execute-narrowed-to-span)
@@ -278,7 +278,7 @@ changes."
 
 ;; (pm-around-advice 'newline #'polymode-newline-remove-hook-in-orig-buffer)
 
-
+
 ;;; DESKTOP SAVE #194 #240
 
 ;; NB: desktop-save will not save indirect buffer.
@@ -309,7 +309,7 @@ This is done by modifying `uniquify-buffer-base-name' to `pm--core-buffer-name'.
 (with-eval-after-load "desktop"
   (advice-add #'desktop-save-buffer-p :before-while #'polymode-fix-desktop-save-buffer-p))
 
-
+
 ;;; MATLAB #199
 ;; matlab-mode is an old non-standard mode which doesn't trigger
 ;; `after-change-major-mode-hook`. As a result polymode cannot detect that
@@ -317,7 +317,7 @@ This is done by modifying `uniquify-buffer-base-name' to `pm--core-buffer-name'.
 ;; Explicitly trigger font-lock as a workaround.
 (add-hook 'matlab-mode-hook (lambda () (font-lock-mode t)))
 
-
+
 ;;; Undo Tree (#230)
 ;; Not clear why this fix works, or even why the problem occurs.
 (declare-function make-undo-tree "undo-tree")
@@ -331,7 +331,7 @@ This is done by modifying `uniquify-buffer-base-name' to `pm--core-buffer-name'.
 (eval-after-load 'undo-tree
   '(add-hook 'polymode-init-inner-hook 'polymode-init-undo-tree-maybe))
 
-
+
 ;;; EVIL
 (declare-function evil-change-state "evil-core")
 (defun polymode-switch-buffer-keep-evil-state-maybe (old-buffer new-buffer)
@@ -346,7 +346,7 @@ This is done by modifying `uniquify-buffer-base-name' to `pm--core-buffer-name'.
 (eval-after-load 'evil-core
   '(add-hook 'polymode-after-switch-buffer-hook 'polymode-switch-buffer-keep-evil-state-maybe))
 
-
+
 ;;; HL line
 (defvar hl-line-mode)
 (defvar global-hl-line-mode)
@@ -363,7 +363,7 @@ This is done by modifying `uniquify-buffer-base-name' to `pm--core-buffer-name'.
 (eval-after-load 'hl-line
   '(add-hook 'polymode-after-switch-buffer-hook 'polymode-switch-buffer-hl-unhighlight))
 
-
+
 ;;; YAS
 
 (with-eval-after-load "yasnippet"
@@ -372,7 +372,7 @@ This is done by modifying `uniquify-buffer-base-name' to `pm--core-buffer-name'.
 
 (provide 'polymode-compat)
 
-
+
 ;;; Multiple cursors
 
 (defvar mc--executing-command-for-fake-cursor)

--- a/polymode-core.el
+++ b/polymode-core.el
@@ -112,7 +112,7 @@
    (replace-regexp-in-string "^ +" "" pm--core-buffer-name)))
 
 
-
+
 ;;; CUSTOM
 
 ;;;###autoload
@@ -218,7 +218,7 @@ The hook is run in chunkmode's body buffer from `pm-initialze'
 objects provides same functionality for narrower scope. See also
 `polymode-init-host-hook'.")
 
-
+
 ;;; Mode Macros
 
 (defun polymode--define-chunkmode (constructor name parent doc key-args)
@@ -297,7 +297,7 @@ key-value pairs. See the documentation of the class
   (polymode--define-chunkmode 'pm-inner-auto-chunkmode name parent doc key-args))
 
 
-
+
 ;;; MESSAGES
 
 (defvar pm-extra-span-info nil)
@@ -321,7 +321,7 @@ key-value pairs. See the documentation of the class
         (format "%s[%s %s-%s %s]" extra type beg end oname)
       (format "[%s %s-%s %s]%s" type beg end oname extra))))
 
-
+
 ;;; SPANS
 
 (defsubst pm-base-buffer ()
@@ -857,7 +857,7 @@ TYPE is either a symbol or a list of symbols of span types."
       (quit nil))
     sofar))
 
-
+
 ;;; OBJECT HOOKS
 
 (defun pm--run-derived-mode-hooks ()
@@ -920,7 +920,7 @@ Parents' hooks are run first."
               funs)
       (mapc #'funcall funs))))
 
-
+
 ;;; BUFFER SELECTION
 
 ;; Transfer of the buffer-undo-list is managed internally by emacs
@@ -1284,7 +1284,7 @@ behavior."
      ,@body))
 
 
-
+
 ;;; HOOKS
 ;; There is also `poly-lock-after-change' in poly-lock.el
 
@@ -1386,7 +1386,7 @@ NEW-MODE can be t in which case mode is picked from the
 
 (add-hook 'after-change-major-mode-hook #'polymode-after-change-major-mode-cleanup)
 
-
+
 ;;; CORE ADVICE
 
 (defun pm-around-advice (fun advice)
@@ -1437,7 +1437,7 @@ Used in advises."
 ;; (advice-remove #'kill-buffer #'polymode-with-current-base-buffer)
 ;; (advice-remove #'find-alternate-file #'polymode-with-current-base-buffer)
 
-
+
 ;;; FILL
 
 ;; FIXME: this is an incomplete heuristic and breaks on adjacent multi-span
@@ -1459,7 +1459,7 @@ ARG is the same as in `forward-paragraph'"
       (pm-goto-span-of-type (car cur-span) (if neg 1 -1)))
     out))
 
-
+
 ;;; SYNTAX
 
 (defun pm--call-syntax-propertize-original (start end)
@@ -1628,7 +1628,7 @@ ARG is the same as in `forward-paragraph'"
 ;;           (funcall orig-fun beg end)))
 ;;     (funcall orig-fun beg end)))
 
-
+
 ;;; INTERNAL UTILITIES
 
 (defun pm--set-transient-map (commands)
@@ -1865,7 +1865,7 @@ Elements of LIST can be either strings or symbols."
                collection))
     (completing-read prompt collection predicate require-match initial-input hist def inherit-input-method)))
 
-
+
 ;;; WEAVING and EXPORTING
 ;; fixme: move all these into separate polymode-process.el?
 (defvar polymode-exporter-output-file-format)

--- a/polymode-debug.el
+++ b/polymode-debug.el
@@ -33,7 +33,7 @@
 (require 'poly-lock)
 (require 'trace)
 
-
+
 ;;; MINOR MODE
 
 (defvar pm--underline-overlay
@@ -102,7 +102,7 @@ Key bindings:
 ;;;###autoload
 (define-globalized-minor-mode pm-debug-mode pm-debug-minor-mode pm-debug-minor-mode-on)
 
-
+
 ;;; INFO
 
 (cl-defgeneric pm-debug-info (chunkmode))
@@ -160,7 +160,7 @@ With NO-CACHE prefix, don't use cached values of the span."
       (message "<%s> cb:%s %s" (or where "") (current-buffer) poses)))
   nil)
 
-
+
 ;;; TOGGLING
 
 (defvar pm-debug-display-info-message nil)
@@ -224,7 +224,7 @@ With NO-CACHE prefix, don't use cached values of the span."
           pm-allow-after-change-hook t
           pm-allow-post-command-hook t)))
 
-
+
 ;;; FONT-LOCK
 
 (defun pm-debug-fontify-current-span ()
@@ -243,7 +243,7 @@ With NO-CACHE prefix, don't use cached values of the span."
     (poly-lock-flush (point-min) (point-max))
     (poly-lock-fontify-now (point-min) (point-max))))
 
-
+
 ;;; TRACING
 
 (defvar pm-traced-functions
@@ -389,7 +389,7 @@ currently traced functions."
 ;; (advice-remove #'trace-entry-message #'pm-trace--fix-args-for-tracing)
 ;; (advice-remove #'trace-exit-message #'pm-trace--fix-args-for-tracing)
 
-
+
 ;;; RELEVANT VARIABLES
 
 (defvar pm-debug-relevant-variables
@@ -480,7 +480,7 @@ buffer, if 'message issue a message, if nil just return a list of values."
           out-buf))
     (pop-to-buffer out-buf)))
 
-
+
 ;;; HIGHLIGHT
 
 (defun pm-debug-highlight-current-span ()

--- a/polymode-export.el
+++ b/polymode-export.el
@@ -195,7 +195,7 @@ that call a shell command. SENTINEL is the process sentinel."
                          (concat "Exporting " from "-->" to " with command:\n\n     "
                                  command "\n\n")))
 
-
+
 ;;; METHODS
 
 (cl-defgeneric pm-export (exporter from to &optional ifile)
@@ -212,7 +212,7 @@ that call a shell command. SENTINEL is the process sentinel."
   (let ((cb (pm--wrap-callback exporter :sentinel ifile)))
     (pm--process-internal exporter from to ifile cb (eieio-oref exporter 'quote))))
 
-
+
 ;; UI
 
 (defvar pm--exporter-hist nil)
@@ -389,7 +389,7 @@ for each polymode in CONFIGS."
      (object-add-to-list (symbol-value pm) :exporters ',exporter)
      (when ,default (oset (symbol-value pm) :exporter ',exporter))))
 
-
+
 ;;; GLOBAL EXPORTERS
 (define-obsolete-variable-alias 'pm-exporter/pandoc 'poly-pandoc-exporter "v0.2")
 (defcustom poly-pandoc-exporter

--- a/polymode-methods.el
+++ b/polymode-methods.el
@@ -29,7 +29,7 @@
 
 (require 'polymode-core)
 
-
+
 ;;; INITIALIZATION
 
 (cl-defgeneric pm-initialize (object)
@@ -223,7 +223,7 @@ initialized. Return the buffer."
 
     (current-buffer)))
 
-
+
 ;;; BUFFER CREATION
 
 (cl-defgeneric pm-get-buffer-create (chunkmode &optional type)
@@ -306,7 +306,7 @@ Create and initialize the buffer if does not exist yet.")
        (setq -tail-buffer buff))
       (_ (error "Type must be one of 'body, 'head or 'tail")))))
 
-
+
 ;;; SPAN MANIPULATION
 
 (cl-defgeneric pm-get-span (chunkmode &optional pos)
@@ -414,7 +414,7 @@ TAIL-BEG TAIL-END).")
                  (object-add-to-list pm/polymode '-auto-innermodes innermode)
                  innermode)))))))))
 
-
+
 ;;; INDENT
 
 ;; indent-region-line-by-line for polymode buffers (more efficient, works on
@@ -664,7 +664,7 @@ to indent."
           (setq offset (pm--object-value offset)))
         (indent-line-to (max 0 (+ (current-indentation) offset (or offset2 0))))))))
 
-
+
 ;;; FACES
 (cl-defgeneric pm-get-adjust-face (chunkmode type))
 

--- a/polymode-weave.el
+++ b/polymode-weave.el
@@ -159,7 +159,7 @@ are ignored."
                          (concat "weaving " from-to-id " with command:\n\n     "
                                  command "\n\n")))
 
-
+
 ;;; METHODS
 
 (declare-function pm-export "polymode-export")
@@ -186,7 +186,7 @@ specification will be called.")
         (pm--export-spec (and pm--output-not-real pm--export-spec)))
     (pm--process-internal weaver fromto-id nil ifile cb (eieio-oref weaver 'quote))))
 
-
+
 ;; UI
 
 (defvar-local pm--weaver-hist nil)

--- a/polymode.el
+++ b/polymode.el
@@ -99,7 +99,7 @@ Lives on `polymode-prefix-key' in polymode buffers.")
     ["Export" polymode-export]
     ["Set Exporter" polymode-set-exporter]))
 
-
+
 ;;; NAVIGATION
 
 (defun polymode-next-chunk (&optional N)
@@ -171,7 +171,7 @@ Return the number of chunks of the same type moved over."
   (interactive "p")
   (polymode-next-chunk-same-type (- N)))
 
-
+
 ;;; KILL and NARROWING
 
 (defun pm--kill-span (types)
@@ -304,7 +304,7 @@ is bound on M\\=-n M\\=-m (the default)
         (pop-to-buffer buf `(nil . ((inhibit-same-window . ,pop-up-windows))))
       (message "No polymode process buffers found."))))
 
-
+
 ;;; EVALUATION
 
 (defvar polymode-eval-map
@@ -408,7 +408,7 @@ non-nil, don't throw if `polymode-eval-region-function' is nil."
   (interactive)
   (polymode-eval-region (point) (point-max) "Eval buffer till end"))
 
-
+
 ;;; DEFINE
 
 (defun pm--config-name (symbol &optional must-exist)


### PR DESCRIPTION
I've used org-brain package that uses polymode internally. But in some environment, Emacs cannot load some polymode functions. I've checked that loading succeeded after removing ^L characters from all files.

Description
- Loading elisp files failed due to the ^L characters
- Error occurred: 
  Error in package--load-files-for-activation: (invalid-function define-hostmode)
Checking /home/sukbeom/.emacs.d/elpa/polymode-20200606.1106...
