### PR TITLE
[ typo ] pm-host/markdown renamed to poly-markdown-hostmode

### DIFF
--- a/docs/defining-polymodes.md
+++ b/docs/defining-polymodes.md
@@ -77,7 +77,7 @@ Finally, use the host and inner modes defined earlier to define the
 
 ```el
 (define-polymode poly-markdown-mode
-  :hostmode 'pm-host/markdown
+  :hostmode 'poly-markdown-hostmode
   :innermodes '(poly-markdown-yaml-metadata-innermode
                 poly-markdown-fenced-code-innermode))
 ```


### PR DESCRIPTION
Earlier in the doc we introduce

```
(define-hostmode poly-markdown-hostmode
  :mode 'markdown-mode)
```

but when putting everything together we end up with:

```
(define-polymode poly-markdown-mode
  :hostmode 'pm-host/markdown
  :innermodes '(poly-markdown-yaml-metadata-innermode
                poly-markdown-fenced-code-innermode))
```

I guess the first snippet was changed at the same time the convention was changed
and led to [these `obsolete-variable`s](https://github.com/polymode/polymode/blob/master/polymode-base.el#L35-L85) but the second was forgotten.