### PR TITLE
Make update scripts work on MacOS

### DIFF
--- a/targets/template.sh
+++ b/targets/template.sh
@@ -3,35 +3,40 @@
 OUTDIR=$1
 MODULE=$(basename $OUTDIR)
 
+CP=cp
+T_ARG=T
+SEDI=(sed -i)
+$CP --version >/dev/null 2>&1 || { type -t gcp >/dev/null 2>&1 && CP=gcp; } || T_ARG=
+sed --version >/dev/null 2>&1 || SEDI+=('')
 POLYMODE_VERSION=$(grep Version polymode.el | sed 's/.*Version: *\(.*\) */\1/')
 
 echo "-- Copying template to $OUTDIR"
-cp  -Tfr template/ $OUTDIR
+$CP -${T_ARG}fr template/ $OUTDIR/
 
 echo "-- Replacing __MODULE__ with $MODULE"
 for f in "$OUTDIR"/* ;
 do
     if [ ! -d "$f" ]; then
-	  sed -i "s/__MODULE__/$MODULE/g" $f;
+	  "${SEDI[@]}" "s/__MODULE__/$MODULE/g" $f;
     fi
 done
 
 for f in "$OUTDIR"/targets/* ;
 do
     if [ ! -d "$f" ]; then
-	  sed -i "s/__MODULE__/$MODULE/g" $f;
+	  "${SEDI[@]}" "s/__MODULE__/$MODULE/g" $f;
     fi
 done
 
 for f in "$OUTDIR"/tests/* ;
 do
     if [ ! -d "$f" ]; then
-	  sed -i "s/__MODULE__/$MODULE/g" $f;
+	  "${SEDI[@]}" "s/__MODULE__/$MODULE/g" $f;
     fi
 done
 
 echo "-- Creating $OUTDIR/$MODULE.el"
-sed -i "s/__POLYMODE_VERSION__/$POLYMODE_VERSION/g" $OUTDIR/poly-xyz.el
+"${SEDI[@]}" "s/__POLYMODE_VERSION__/$POLYMODE_VERSION/g" $OUTDIR/poly-xyz.el
 mv -n $OUTDIR/poly-xyz.el $OUTDIR/$MODULE.el
 mv -n $OUTDIR/README-xyz.md $OUTDIR/README.md
 mv -n $OUTDIR/tests/xyz-tests.el $OUTDIR/tests/$MODULE-tests.el

--- a/targets/template.sh
+++ b/targets/template.sh
@@ -4,39 +4,40 @@ OUTDIR=$1
 MODULE=$(basename $OUTDIR)
 
 CP=cp
-T_ARG=T
-SEDI=(sed -i)
-$CP --version >/dev/null 2>&1 || { type -t gcp >/dev/null 2>&1 && CP=gcp; } || T_ARG=
-sed --version >/dev/null 2>&1 || SEDI+=('')
-POLYMODE_VERSION=$(grep Version polymode.el | sed 's/.*Version: *\(.*\) */\1/')
+CP_T_ARG=T
+SED=sed
+SED_I_ARG=(-i)
+$CP --version >/dev/null 2>&1 || { type -t gcp >/dev/null 2>&1 && CP=gcp; } || CP_T_ARG=
+$SED --version >/dev/null 2>&1 || { type -t gsed >/dev/null 2>&1 && SED=gsed; } || SED_I_ARG+=('')
+POLYMODE_VERSION=$(grep Version polymode.el | $SED 's/.*Version: *\(.*\) */\1/')
 
 echo "-- Copying template to $OUTDIR"
-$CP -${T_ARG}fr template/ $OUTDIR/
+$CP -${CP_T_ARG}fr template/ $OUTDIR/
 
 echo "-- Replacing __MODULE__ with $MODULE"
 for f in "$OUTDIR"/* ;
 do
     if [ ! -d "$f" ]; then
-	  "${SEDI[@]}" "s/__MODULE__/$MODULE/g" $f;
+	  $SED "${SED_I_ARG[@]}" "s/__MODULE__/$MODULE/g" $f;
     fi
 done
 
 for f in "$OUTDIR"/targets/* ;
 do
     if [ ! -d "$f" ]; then
-	  "${SEDI[@]}" "s/__MODULE__/$MODULE/g" $f;
+	  $SED "${SED_I_ARG[@]}" "s/__MODULE__/$MODULE/g" $f;
     fi
 done
 
 for f in "$OUTDIR"/tests/* ;
 do
     if [ ! -d "$f" ]; then
-	  "${SEDI[@]}" "s/__MODULE__/$MODULE/g" $f;
+	  $SED "${SED_I_ARG[@]}" "s/__MODULE__/$MODULE/g" $f;
     fi
 done
 
 echo "-- Creating $OUTDIR/$MODULE.el"
-"${SEDI[@]}" "s/__POLYMODE_VERSION__/$POLYMODE_VERSION/g" $OUTDIR/poly-xyz.el
+$SED "${SED_I_ARG[@]}" "s/__POLYMODE_VERSION__/$POLYMODE_VERSION/g" $OUTDIR/poly-xyz.el
 mv -n $OUTDIR/poly-xyz.el $OUTDIR/$MODULE.el
 mv -n $OUTDIR/README-xyz.md $OUTDIR/README.md
 mv -n $OUTDIR/tests/xyz-tests.el $OUTDIR/tests/$MODULE-tests.el

--- a/targets/update-versions.sh
+++ b/targets/update-versions.sh
@@ -5,11 +5,12 @@
 
 set -e
 
-SEDI=(sed -i)
-sed --version >/dev/null 2>&1 || SEDI+=('')
+SED=sed
+SED_I_ARG=(-i)
+$SED --version >/dev/null 2>&1 || { type -t gsed >/dev/null 2>&1 && SED=gsed; } || SED_I_ARG+=('')
 # DIRS=( "../poly-erb")
 DIRS=( "../polymode" "../poly-*" )
-VERSION=$(grep Version polymode.el | sed 's/.*Version: *\(.*\) */\1/')
+VERSION=$(grep Version polymode.el | $SED 's/.*Version: *\(.*\) */\1/')
 
 for d in ${DIRS[@]} ;
 do
@@ -19,8 +20,8 @@ do
     if git rev-parse "v$VERSION" >/dev/null 2>&1; then
         echo "** TAG EXISTS";
     else
-        "${SEDI[@]}" "s/\(;; Version: .\+\)/;; Version: $VERSION/g" $pkg
-        "${SEDI[@]}" "s/(\(poly-\?[a-z]\+\) \"[0-9.]\+\")/(\1 \"$VERSION\")/g" $pkg
+        $SED "${SED_I_ARG[@]}" "s/\(;; Version: .\+\)/;; Version: $VERSION/g" $pkg
+        $SED "${SED_I_ARG[@]}" "s/(\(poly-\?[a-z]\+\) \"[0-9.]\+\")/(\1 \"$VERSION\")/g" $pkg
         git add $pkg
         git commit -m "Version $VERSION"
         git fetch --tags

--- a/targets/update-versions.sh
+++ b/targets/update-versions.sh
@@ -5,6 +5,8 @@
 
 set -e
 
+SEDI=(sed -i)
+sed --version >/dev/null 2>&1 || SEDI+=('')
 # DIRS=( "../poly-erb")
 DIRS=( "../polymode" "../poly-*" )
 VERSION=$(grep Version polymode.el | sed 's/.*Version: *\(.*\) */\1/')
@@ -17,8 +19,8 @@ do
     if git rev-parse "v$VERSION" >/dev/null 2>&1; then
         echo "** TAG EXISTS";
     else
-        sed -i "s/\(;; Version: .\+\)/;; Version: $VERSION/g" $pkg
-        sed -i "s/(\(poly-\?[a-z]\+\) \"[0-9.]\+\")/(\1 \"$VERSION\")/g" $pkg
+        "${SEDI[@]}" "s/\(;; Version: .\+\)/;; Version: $VERSION/g" $pkg
+        "${SEDI[@]}" "s/(\(poly-\?[a-z]\+\) \"[0-9.]\+\")/(\1 \"$VERSION\")/g" $pkg
         git add $pkg
         git commit -m "Version $VERSION"
         git fetch --tags


### PR DESCRIPTION
* Look for `gcp` if our `cp` command is not from GNU
* Cope with BSD-style `cp` that does not understand `-T`
* Cope with BSD-style `sed` that requires an empty argument (`''`) after `-i` when editing in-place without a backup file.

Behavior verified on MacOS Mojave with and without a usable `gcp`, and on Scientific Linux 7.