### PR TITLE
Indentation infinite recursion

### DIFF
--- a/polymode-methods.el
+++ b/polymode-methods.el
@@ -165,12 +165,12 @@ initialized. Return the buffer."
 
     ;; INDENTATION
     (setq-local pm--indent-line-function-original
-                (if (memq indent-line-function '(indent-relative indent-relative-maybe))
+                (if (memq indent-line-function '(indent-relative indent-relative-maybe pm-indent-line-dispatcher))
                     #'pm--indent-line-basic
                   indent-line-function))
     (setq-local indent-line-function #'pm-indent-line-dispatcher)
     (setq-local pm--indent-region-function-original
-                (if (memq indent-region-function '(nil indent-region-line-by-line))
+                (if (memq indent-region-function '(nil indent-region-line-by-line pm-indent-region))
                     #'pm--indent-region-line-by-line
                   indent-region-function))
     (setq-local indent-region-function #'pm-indent-region)

--- a/polymode.el
+++ b/polymode.el
@@ -616,9 +616,6 @@ most frequently used slots are:
                     ;; non-nil (like in define-mirror-mode)
                     doc keymap-name)
            (interactive)
-           ;; Don't restore in desktop-save-mode #289
-           (with-eval-after-load 'desktop
-             (add-to-list 'desktop-minor-mode-table '(,mode nil)))
            (let ((,last-message (current-message))
                  (state (cond
                          ((numberp arg) (> arg 0))


### PR DESCRIPTION
Commit 9367c27 results in byte-compilation warnings:
```
dick@dick:~/polymode$ emacs -Q --batch -L . -l polymode \
--eval "(byte-compile '(define-polymode poly-test-mode))"
Warning: reference to free variable ‘desktop-minor-mode-table’
Warning: assignment to free variable ‘desktop-minor-mode-table’
```

Rather than resorting to the broadest brush, perhaps we could more surgically deal with the recursive indent calls described in #289 