### PR TITLE
fix issue of incorrect indentation to inner mode tail

### DIFF
--- a/polymode-methods.el
+++ b/polymode-methods.el
@@ -655,7 +655,7 @@ to indent."
             ;; for instance.
             (goto-char sbeg)))
         (back-to-indentation)
-        (- (point) (point-at-bol))))))
+        (current-column)))))
 
 (defun pm--+-indent-offset-on-this-line (span)
   (if (re-search-forward "\\([+-]\\)indent" (point-at-eol) t)


### PR DESCRIPTION
If inner mode head line is indented by tabs, then following calculation is not correct for tail indentation:

   (- (point) (point-at-bol))

by just using (current-column) should be OK.

Rongsong