### PR TITLE
add buffer-file-truename to transferred variables

### DIFF
--- a/polymode-core.el
+++ b/polymode-core.el
@@ -966,6 +966,7 @@ Parents' hooks are run first."
 (define-obsolete-variable-alias 'pm-move-vars-from-base 'polymode-move-these-vars-from-base-buffer "v0.1.6")
 (defvar polymode-move-these-vars-from-base-buffer
   '(buffer-file-name
+    buffer-file-truename
     ;; ideally this one should be merged across all buffers
     buffer-display-table
     outline-regexp


### PR DESCRIPTION
I was hacking up a quick `lean-org-mode` using `polymode` and came across a bug where they were using `buffer-file-truename` in `lean4-mode` to find the relevant lean project. Even though the code was defensive around the existence of `buffer-file-name` it then went on to use `buffer-file-truename` which then failed due to being `nil` which is (reasonably) unexpected.  I added `buffer-file-truname` to the list of transferred variables which solved the problem; so I thought this might be more consistent to include in general.

I have to say using `polymode` is rather miraculous way of enabling literate programming.  Many thanks for developing this .
