### PR TITLE
Support olivetti-mode

### DIFF
--- a/polymode-core.el
+++ b/polymode-core.el
@@ -1010,6 +1010,7 @@ Parents' hooks are run first."
   "Minor modes to move from base buffer on buffer switch.")
 (defvar polymode-move-these-minor-modes-from-old-buffer
   '(linum-mode
+    olivetti-mode
     visual-line-mode
     visual-fill-column-mode
     writeroom-mode

--- a/polymode-core.el
+++ b/polymode-core.el
@@ -989,6 +989,7 @@ Parents' hooks are run first."
     line-move-visual
     left-margin-width
     right-margin-width
+    olivetti-body-width
     overwrite-mode
     selective-display
     text-scale-mode


### PR DESCRIPTION
Right now, when using polymode you need to manually (de)activate [`olivetti-mode`](https://github.com/rnkn/olivetti) for each of the sub-modes in a buffer.

I think it's a sensible default to keep the visual margins in sync across buffers. Otherwise, the buffer switches abruptly as you scroll between sub-modes.

Tested locally with 
```elisp
(add-to-list 'polymode-move-these-minor-modes-from-old-buffer 'olivetti-mode)
(add-to-list 'polymode-move-these-vars-from-old-buffer 'olivetti-body-width)
```