### PR TITLE
Fixing broken screenshots links

### DIFF
--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -3,18 +3,18 @@
 
 ### Markdown
 
-<img src="../img/Rmd.png" width="500px"/>
+<img src="./img/Rmd.png" width="500px"/>
 
-<img src="../img/rapport.png" width="500px"/>
+<img src="./img/rapport.png" width="500px"/>
 
 ### Org mode
 
-<img src="../img/org.png" width="500px"/>
+<img src="./img/org.png" width="500px"/>
 
 ### Ess-help buffer
 
-<img src="../img/ess-help.png" width="500px"/>
+<img src="./img/ess-help.png" width="500px"/>
 
 ### C++R
-<img src="../img/cppR.png" width="500px"/>
+<img src="./img/cppR.png" width="500px"/>
 


### PR DESCRIPTION
The links in the `screenshots.md` file were broken because they were referring to the wrong `img` directory