### PR TITLE
ci: fix lints and obsolete methods

### DIFF
--- a/polymode-compat.el
+++ b/polymode-compat.el
@@ -260,7 +260,7 @@ are passed to ORIG-FUN."
         (setq end (or end (point-max)))
         (let ((cmode major-mode)
               (end-eol (save-excursion (goto-char end)
-                                       (point-at-eol)))
+                                       (line-end-position)))
               line-acc acc)
           (pm-map-over-modes
            (lambda (sbeg send)
@@ -273,15 +273,15 @@ are passed to ORIG-FUN."
                        ;; first line of mode; use line-acc
                        (setq acc (append line-acc acc))
                        (setq line-acc nil))
-                     ;; if cur-mode follows after end on same line, accumulate the
-                     ;; last line but not the actual text
+                     ;; if cur-mode follows after end on same line,
+                     ;; accumulate the last line but not the actual text
                      (when (< beg1 end)
                        (push (buffer-substring-no-properties beg1 end1) acc)))
                  (goto-char beg1)
-                 (if (<= end1 (point-at-eol))
+                 (if (<= end1 (line-end-position))
                      (when (< beg1 end1) ; don't accumulate on last line
                        (push (make-string (- end1 beg1) ? ) line-acc))
-                   (while (< (point-at-eol) end1)
+                   (while (< (line-end-position) end1)
                      (push "\n" acc)
                      (forward-line 1))
                    (setq line-acc (list (make-string (- end1 (point)) ? )))))))
@@ -434,7 +434,8 @@ changes."
 ;; save the buffers with un-hidden name.
 
 (defun polymode-fix-desktop-buffer-info (fn buffer)
-  "Unhide poly-mode base buffer which is hidden by removing the leading spaces from the name."
+  "Unhide poly-mode base buffer which is hidden by removing
+the leading spaces from the name."
   (with-current-buffer buffer
     (let ((out (funcall fn buffer)))
       (when (and polymode-mode

--- a/polymode-debug.el
+++ b/polymode-debug.el
@@ -104,9 +104,7 @@ Key bindings:
              (pm-base-buffer) (with-current-buffer (pm-base-buffer) (point))
              (buffer-name) (point)
              (get-buffer-window (pm-base-buffer))
-             (with-current-buffer (pm-base-buffer) (window-point))
-             ;; FIXME: This arg is not used.
-             (window-point))))
+             (with-current-buffer (pm-base-buffer) (window-point)))))
 
 ;; (defun pm-debug-beore-change (&rest r)
 ;;   (pm--debug-report-point "|before|" this-command))
@@ -420,6 +418,8 @@ currently traced functions."
       (setq args "[...]"))
     (funcall orig-fn fn level args context)))
 
+(declare-function trace-entry-message "ext:")
+(declare-function trace-exit-message "ext:")
 (advice-add #'trace-entry-message :around #'pm-trace--fix-args-for-tracing)
 (advice-add #'trace-exit-message :around #'pm-trace--fix-args-for-tracing)
 ;; (advice-remove #'trace-entry-message #'pm-trace--fix-args-for-tracing)

--- a/polymode-export.el
+++ b/polymode-export.el
@@ -351,7 +351,7 @@ If NO-ASK-IF-1 is non-nil, don't ask if there is only one exporter."
   (interactive)
   (unless pm/polymode
     (error "No pm/polymode object found. Not in polymode buffer?"))
-  (let* ((weavers (delete-dups (pm--oref-with-parents pm/polymode :weavers)))
+  (let* ((weavers (delete-dups (pm--oref-with-parents pm/polymode 'weavers)))
          (exporters (pm--abrev-names
                      "pm-exporter/\\|-exporter"
                      (cl-delete-if-not
@@ -368,7 +368,7 @@ If NO-ASK-IF-1 is non-nil, don't ask if there is only one exporter."
                                                                  when (pm--selector-match el (concat "dummy." (nth 2 w)))
                                                                  return t))
                                      return t)))
-                      (delete-dups (pm--oref-with-parents pm/polymode :exporters)))))
+                      (delete-dups (pm--oref-with-parents pm/polymode 'exporters)))))
          (sel (if exporters
                   (if (and no-ask-if-1 (= (length exporters) 1))
                       (car exporters)
@@ -378,7 +378,7 @@ If NO-ASK-IF-1 is non-nil, don't ask if there is only one exporter."
     (setq pm--exporter-hist (delete-dups pm--exporter-hist))
     (setq-local pm--export:from-last nil)
     (setq-local pm--export:to-last nil)
-    (oset pm/polymode :exporter out)
+    (oset pm/polymode 'exporter out)
     out))
 
 (defmacro polymode-register-exporter (exporter default &rest configs)
@@ -386,8 +386,8 @@ If NO-ASK-IF-1 is non-nil, don't ask if there is only one exporter."
 When DEFAULT is non-nil, also make EXPORTER the default exporter
 for each polymode in CONFIGS."
   `(dolist (pm ',configs)
-     (object-add-to-list (symbol-value pm) :exporters ',exporter)
-     (when ,default (oset (symbol-value pm) :exporter ',exporter))))
+     (object-add-to-list (symbol-value pm) 'exporters ',exporter)
+     (when ,default (oset (symbol-value pm) 'exporter ',exporter))))
 
 
 ;;; GLOBAL EXPORTERS

--- a/polymode-methods.el
+++ b/polymode-methods.el
@@ -63,7 +63,7 @@ Ran by the polymode mode function."
           ;; Set if nil! This allows unspecified host chunkmodes to be used in
           ;; minor modes.
           (host-mode (or (eieio-oref hostmode 'mode)
-                         (oset hostmode :mode major-mode))))
+                         (oset hostmode 'mode major-mode))))
       ;; FIXME: mode hooks and local var hacking happens here. Need to move it
       ;; to the end.
       (pm--mode-setup host-mode)

--- a/polymode-weave.el
+++ b/polymode-weave.el
@@ -258,8 +258,8 @@ specification."
 When DEFAULT is non-nil, also make weaver the default WEAVER for
 each polymode in CONFIGS."
   `(dolist (pm ',configs)
-     (object-add-to-list (symbol-value pm) :weavers ',weaver)
-     (when ,default (oset (symbol-value pm) :weaver ',weaver))))
+     (object-add-to-list (symbol-value pm) 'weavers ',weaver)
+     (when ,default (oset (symbol-value pm) 'weaver ',weaver))))
 
 (defun polymode-set-weaver ()
   "Set the current weaver for this polymode."
@@ -268,12 +268,12 @@ each polymode in CONFIGS."
     (error "No pm/polymode object found. Not in polymode buffer?"))
   (let* ((weavers (pm--abrev-names
                    "pm-weaver/\\|-weaver$"
-                   (delete-dups (pm--oref-with-parents pm/polymode :weavers))))
+                   (delete-dups (pm--oref-with-parents pm/polymode 'weavers))))
          (sel (pm--completing-read "Choose weaver: " weavers nil t nil 'pm--weaver-hist))
          (out (intern (cdr sel))))
     (setq pm--weaver-hist (delete-dups pm--weaver-hist))
     (setq-local pm--weave:fromto-last nil)
-    (oset pm/polymode :weaver out)
+    (oset pm/polymode 'weaver out)
     out))
 
 (provide 'polymode-weave)

--- a/polymode.el
+++ b/polymode.el
@@ -53,7 +53,8 @@ Not effective after loading the polymode library.
 Instead of setting this key you can programatically bind it directly
 in `polymode-minor-mode-map` keymap:
 
- (define-key polymode-minor-mode-map (kbd \"M-n\") nil)  ;unbind the default M-n prefix
+ (define-key polymode-minor-mode-map (kbd \"M-n\") nil)
+ ;unbind the default M-n prefix
  (define-key polymode-minor-mode-map (kbd \"C-c n\") polymode-map)
 ")
 
@@ -443,7 +444,7 @@ non-nil, don't throw if `polymode-eval-region-function' is nil."
         (pi parent-conf)
         (parent-map))
     (while pi
-      (let ((map (and (slot-boundp pi :keylist)
+      (let ((map (and (slot-boundp pi 'keylist)
                       (eieio-oref pi 'keylist))))
         (when map
           (if (and (symbolp map)
@@ -453,7 +454,7 @@ non-nil, don't throw if `polymode-eval-region-function' is nil."
               (setq parent-map map
                     pi nil)
             ;; list, descend to next parent and append the key list to keylist
-            (setq pi (and (slot-boundp pi :parent-instance)
+            (setq pi (and (slot-boundp pi 'parent-instance)
                           (eieio-oref pi 'parent-instance))
                   keylist (append map keylist))))))
     (when (and parent-map (symbolp parent-map))


### PR DESCRIPTION
Fix warning about accessing slot via obsolete initarg name and some other warning about obsoleted functions